### PR TITLE
Fix typos in theme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Sparky Black
 
-This contains the SparkyOS default KDE Theme based on Breeze, Oxygen, Lines and others themes
+This contains the SparkyOS default KDE Theme based on Breeze, Oxygen, Lines and other themes
 
 Copyright (C) 2018-2020 Paweł Pijanowski & Daniel Campos Ramos
 
@@ -12,4 +12,6 @@ You should have received a copy of the GNU General Public License along with thi
 
 Dependencies:
 
-kde sddm plymouth
+- kde
+- sddm
+- plymouth

--- a/usr/share/plymouth/themes/sparky-lines/sparky-lines.plymouth
+++ b/usr/share/plymouth/themes/sparky-lines/sparky-lines.plymouth
@@ -1,5 +1,5 @@
 [Plymouth Theme]
-Name=Modifyed Default Debian 8.0 Jessie theme
+Name=Modified Default Debian 8.0 Jessie theme
 Description=A theme that features a white sparky logo on a blue-green background surrounded by thin curves
 ModuleName=script
 

--- a/usr/share/sddm/themes/sparky-black/Main.qml
+++ b/usr/share/sddm/themes/sparky-black/Main.qml
@@ -61,7 +61,7 @@ Image {
     Controls.StackView {
         id: stackView
 
-        //Display the loginpromt only in the primary screen
+        //Display the login prompt only in the primary screen
         readonly property rect geometry: screenModel.geometry(screenModel.primary)
         width: geometry.width
         x: geometry.x


### PR DESCRIPTION
## Summary
- fix README typos and add bullet list for dependencies
- correct comment typo in SDDM theme
- fix misspelling in Plymouth theme

## Testing
- `echo "No tests" && true`

------
https://chatgpt.com/codex/tasks/task_e_683f47969c7c8324961bc4ecc155fc35